### PR TITLE
Add upper method to airport object

### DIFF
--- a/faadelays/__init__.py
+++ b/faadelays/__init__.py
@@ -70,7 +70,7 @@ class AirportConfig:
 class Airport:
     # Class for storing data for an individual airport
     def __init__(self, code, session: ClientSession):
-        self.code = code
+        self.code = code.upper()
         self.name = None
         self.latitude = None
         self.longitude = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faadelays"
-version = "2023.9.0"
+version = "2023.9.1"
 authors = [
   { name="Nathan Tilley", email="nathan@tilley.xyz" },
 ]


### PR DESCRIPTION
This corrects an error where a lowercase airport code passed (e.g. `bos` instead of `BOS`) will not return any data.